### PR TITLE
Fix broken auto versioning on non-master branches

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if exists(git_dir):
             # Includes previous year's commits in case one was merged after the
             # year incremented. Otherwise, the version wouldn't increment.
             "--after=\"master@{" + str(date.today().year - 1) + "-01-01}\"",
-            "master"
+            "HEAD"
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT)


### PR DESCRIPTION
This fixes broken auto-versioning on Azure because of the way Azure checks out the commit it intends to build. Sorry about this (I should have looked at Azure's output a little closer).