### PR TITLE
replace parens with square brackets in config files

### DIFF
--- a/frc_characterization/arm_characterization/templates/Neo/robotconfig.py
+++ b/frc_characterization/arm_characterization/templates/Neo/robotconfig.py
@@ -1,12 +1,12 @@
 {  
   # Ports for the motors
-  'motorPorts': (0,),
+  'motorPorts': [0,],
 
   # NOTE: Inversions of the slaves (i.e. any motor *after* the first on
   # each side of the drive) are *with respect to their master*.  This is
   # different from the other poject types!
   # Inversions for the motors
-  'motorsInverted': (False,),
+  'motorsInverted': [False,],
 
   # Unit of analysis
   # Options:

--- a/frc_characterization/arm_characterization/templates/Simple/robotconfig.py
+++ b/frc_characterization/arm_characterization/templates/Simple/robotconfig.py
@@ -8,13 +8,13 @@
   # 'PWMVictorSPX'
   # 'WPI_TalonSRX'
   # 'WPI_VictorSPX'
-  'controllerTypes': ('Spark',),
+  'controllerTypes': ['Spark',],
   
   # Ports for the motors
-  'motorPorts': (0,),
+  'motorPorts': [0],
 
   # Inversions for the motors
-  'motorsInverted': (False,),
+  'motorsInverted': [False,],
 
   # Unit of analysis
   # Options:

--- a/frc_characterization/arm_characterization/templates/SparkMax/robotconfig.py
+++ b/frc_characterization/arm_characterization/templates/SparkMax/robotconfig.py
@@ -1,12 +1,12 @@
 {  
   # Ports for the motors
-  'motorPorts': (0,),
+  'motorPorts': [0,],
 
   # NOTE: Inversions of the slaves (i.e. any motor *after* the first on
   # each side of the drive) are *with respect to their master*.  This is
   # different from the other poject types!
   # Inversions for the motors
-  'motorsInverted': (False,),
+  'motorsInverted': [False,],
 
   # Unit of analysis
   # Options:

--- a/frc_characterization/arm_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/arm_characterization/templates/Talon/robotconfig.py
@@ -5,13 +5,13 @@
   # 'WPI_VictorSPX'
   # Note: The first motor should always be a TalonSRX, as the VictorSPX
   # does not support encoder connections.
-  'controllerTypes': ('WPI_TalonSRX',),
+  'controllerTypes': ['WPI_TalonSRX',],
   
   # Ports for the motors
-  'motorPorts': (0,),
+  'motorPorts': [0,],
 
   # Inversions for the motors
-  'motorsInverted': (False,),
+  'motorsInverted': [False,],
 
   # Unit of analysis
   # Options:

--- a/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Neo/robotconfig.py
@@ -1,16 +1,16 @@
 {
   # Ports for the left-side motors
-  'leftMotorPorts': (0, 1),
+  'leftMotorPorts': [0, 1],
   # Ports for the right-side motors
-  'rightMotorPorts': (2, 3),
+  'rightMotorPorts': [2, 3],
 
   # NOTE: Inversions of the slaves (i.e. any motor *after* the first on
   # each side of the drive) are *with respect to their master*.  This is
   # different from the other poject types!
   # Inversions for the left-side motors
-  'leftMotorsInverted': (False, False),
+  'leftMotorsInverted': [False, False],
   # Inversions for the right side motors
-  'rightMotorsInverted': (False, False),
+  'rightMotorsInverted': [False, False],
 
   # The total gear reduction between the motor and the wheels, expressed as
   # a fraction [motor turns]/[wheel turns]

--- a/frc_characterization/drive_characterization/templates/Simple/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Simple/robotconfig.py
@@ -8,18 +8,18 @@
   # 'PWMVictorSPX'
   # 'WPI_TalonSRX'
   # 'WPI_VictorSPX'
-  'rightControllerTypes': ('Spark', 'Spark'),
-  'leftControllerTypes': ('Spark', 'Spark'),
+  'rightControllerTypes': ['Spark', 'Spark'],
+  'leftControllerTypes': ['Spark', 'Spark'],
 
   # Ports for the left-side motors
-  'leftMotorPorts': (0, 1),
+  'leftMotorPorts': [0, 1],
   # Ports for the right-side motors
-  'rightMotorPorts': (2, 3),
+  'rightMotorPorts': [2, 3],
 
   # Inversions for the left-side motors
-  'leftMotorsInverted': (False, False),
+  'leftMotorsInverted': [False, False],
   # Inversions for the right side motors
-  'rightMotorsInverted': (False, False),
+  'rightMotorsInverted': [False, False],
 
   # Wheel diameter (in units of your choice - will dictate units of analysis)
   'wheelDiameter': .333,
@@ -30,9 +30,9 @@
   # should take into account gearing between the encoder and the wheels
   'encoderPPR': 512,
   # Ports for the left-side encoder
-  'leftEncoderPorts': (0, 1),
+  'leftEncoderPorts': [0, 1],
   # Ports for the right-side encoder
-  'rightEncoderPorts': (2, 3),
+  'rightEncoderPorts': [2, 3],
   # Whether the left encoder is inverted
   'leftEncoderInverted': False,
   # Whether the right encoder is inverted:

--- a/frc_characterization/drive_characterization/templates/SparkMAX/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/SparkMAX/robotconfig.py
@@ -1,16 +1,16 @@
 {
   # Ports for the left-side motors
-  'leftMotorPorts': (0, 1),
+  'leftMotorPorts': [0, 1],
   # Ports for the right-side motors
-  'rightMotorPorts': (2, 3),
+  'rightMotorPorts': [2, 3],
 
   # NOTE: Inversions of the slaves (i.e. any motor *after* the first on
   # each side of the drive) are *with respect to their master*.  This is
   # different from the other poject types!
   # Inversions for the left-side motors
-  'leftMotorsInverted': (False, False),
+  'leftMotorsInverted': [False, False],
   # Inversions for the right side motors
-  'rightMotorsInverted': (False, False),
+  'rightMotorsInverted': [False, False],
 
   # If your robot has only one encoder, remove all of the right encoder fields
   # Encoder pulses-per-revolution (*NOT* cycles per revolution!)

--- a/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/drive_characterization/templates/Talon/robotconfig.py
@@ -5,18 +5,18 @@
   # 'WPI_VictorSPX'
   # Note: The first motor on each side should always be a TalonSRX, as the
   # VictorSPX does not support encoder connections
-  'rightControllerTypes': ('WPI_TalonSRX', 'WPI_TalonSRX'),
-  'leftControllerTypes': ('WPI_TalonSRX', 'WPI_TalonSRX'),
+  'rightControllerTypes': ['WPI_TalonSRX', 'WPI_TalonSRX'],
+  'leftControllerTypes': ['WPI_TalonSRX', 'WPI_TalonSRX'],
 
   # Ports for the left-side motors
-  'leftMotorPorts': (0, 1),
+  'leftMotorPorts': [0, 1],
   # Ports for the right-side motors
-  'rightMotorPorts': (2, 3),
+  'rightMotorPorts': [2, 3],
 
   # Inversions for the left-side motors
-  'leftMotorsInverted': (False, False),
+  'leftMotorsInverted': [False, False],
   # Inversions for the right side motors
-  'rightMotorsInverted': (False, False),
+  'rightMotorsInverted': [False, False],
 
   # Wheel diameter (in units of your choice - will dictate units of analysis)
   'wheelDiameter': .333,

--- a/frc_characterization/elevator_characterization/templates/Neo/robotconfig.py
+++ b/frc_characterization/elevator_characterization/templates/Neo/robotconfig.py
@@ -1,12 +1,12 @@
 {  
   # Ports for the motors
-  'motorPorts': (0,),
+  'motorPorts': [0,],
 
   # NOTE: Inversions of the slaves (i.e. any motor *after* the first on
   # each side of the drive) are *with respect to their master*.  This is
   # different from the other poject types!
   # Inversions for the motors
-  'motorsInverted': (False,),
+  'motorsInverted': [False,],
 
   # The total gear reduction between the motor and the pulley, expressed as
   # a fraction [motor turns]/[pulley turns]

--- a/frc_characterization/elevator_characterization/templates/Simple/robotconfig.py
+++ b/frc_characterization/elevator_characterization/templates/Simple/robotconfig.py
@@ -5,13 +5,13 @@
   # 'WPI_VictorSPX'
   # Note: The first motor should always be a TalonSRX, as the VictorSPX
   # does not support encoder connections.
-  'controllerTypes': ('Spark',),
+  'controllerTypes': ['Spark',],
   
   # Ports for the motors
-  'motorPorts': (0,),
+  'motorPorts': [0,],
 
   # Inversions for the motors
-  'motorsInverted': (False,),
+  'motorsInverted': [False,],
 
   # Pulley diameter (in units of your choice - will dictate units of analysis)
   'pulleyDiameter': .333,
@@ -20,7 +20,7 @@
   # should take into account gearing between the encoder and the pulley
   'encoderPPR': 512,
   # Ports for the encoder
-  'encoderPorts': (0, 1),
+  'encoderPorts': [0, 1],
   # Whether the encoder is inverted
   'encoderInverted': False,
 }

--- a/frc_characterization/elevator_characterization/templates/SparkMax/robotconfig.py
+++ b/frc_characterization/elevator_characterization/templates/SparkMax/robotconfig.py
@@ -1,12 +1,12 @@
 {  
   # Ports for the motors
-  'motorPorts': (0,),
+  'motorPorts': [0,],
 
   # NOTE: Inversions of the slaves (i.e. any motor *after* the first on
   # each side of the drive) are *with respect to their master*.  This is
   # different from the other poject types!
   # Inversions for the motors
-  'motorsInverted': (False,),
+  'motorsInverted': [False,],
 
   # The total gear reduction between the motor and the pulley, expressed as
   # a fraction [motor turns]/[pulley turns]

--- a/frc_characterization/elevator_characterization/templates/Talon/robotconfig.py
+++ b/frc_characterization/elevator_characterization/templates/Talon/robotconfig.py
@@ -5,13 +5,13 @@
   # 'WPI_VictorSPX'
   # Note: The first motor should always be a TalonSRX, as the VictorSPX
   # does not support encoder connections.
-  'controllerTypes': ('WPI_TalonSRX',),
+  'controllerTypes': ['WPI_TalonSRX',],
   
   # Ports for the motors
-  'motorPorts': (0,),
+  'motorPorts': [0,],
 
   # Inversions for the motors
-  'motorsInverted': (False,),
+  'motorsInverted': [False,],
 
   # Unit of analysis
   # Options:


### PR DESCRIPTION
allows config files to tolerate omission of trailing commas in lists